### PR TITLE
fix: removed name_prefix from IAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,384 +44,67 @@ License
 
 This software is released under the MIT License (see `LICENSE`).
 ----------------------
-## Required Inputs
 
-The following input variables are required:
-
-### docker\_image
-
-Description: Docker image to use for task
-
-Type: `string`
-
-### ecs\_cluster\_arn
-
-Description: ARN of ECS cluster in which the service will be deployed
-
-Type: `string`
-
-### ecs\_security\_group\_id
-
-Description: Security group ID of ECS cluster in which the service will be deployed
-
-Type: `string`
-
-### lb\_bucket\_name
-
-Description: Full name for S3 bucket.
-
-Type: `string`
-
-### vpc\_id
-
-Description: ID of VPC in which ECS cluster is located
-
-Type: `string`
-
-## Optional Inputs
-
-The following input variables are optional (have default values):
-
-### acm\_cert\_domain
-
-Description: Domain name of ACM-managed certificate
-
-Type: `string`
-
-Default: `""`
-
-### alb\_cookie\_duration
-
-Description: Duration of ALB session stickiness cookie in seconds (default 86400)
-
-Type: `string`
-
-Default: `"86400"`
-
-### alb\_enable\_http
-
-Description: Enable HTTP listener in ALB (default false)
-
-Type: `string`
-
-Default: `"false"`
-
-### alb\_enable\_https
-
-Description: Enable HTTPS listener in ALB (default true)
-
-Type: `string`
-
-Default: `"true"`
-
-### alb\_healthcheck\_healthy\_threshold
-
-Description: Number of consecutive successful health checks before marking service as healthy (default 5)
-
-Type: `string`
-
-Default: `"5"`
-
-### alb\_healthcheck\_interval
-
-Description: Time in seconds between ALB health checks (default 30)
-
-Type: `string`
-
-Default: `"30"`
-
-### alb\_healthcheck\_matcher
-
-Description: HTTP response codes to accept as healthy (default 200)
-
-Type: `string`
-
-Default: `"200"`
-
-### alb\_healthcheck\_path
-
-Description: URI path for ALB health checks (default /)
-
-Type: `string`
-
-Default: `"/"`
-
-### alb\_healthcheck\_port
-
-Description: Port for ALB to use when connecting health checks (default same as application traffic)
-
-Type: `string`
-
-Default: `"traffic-port"`
-
-### alb\_healthcheck\_protocol
-
-Description: Protocol for ALB to use when connecting health checks (default HTTP)
-
-Type: `string`
-
-Default: `"HTTP"`
-
-### alb\_healthcheck\_timeout
-
-Description: Timeout in seconds for ALB to use when connecting health checks (default 5)
-
-Type: `string`
-
-Default: `"5"`
-
-### alb\_healthcheck\_unhealthy\_threshold
-
-Description: Number of consecutive failed health checks before marking service as unhealthy (default 2)
-
-Type: `string`
-
-Default: `"5"`
-
-### alb\_internal
-
-Description: Configure ALB as internal-only (default false)
-
-Type: `string`
-
-Default: `"false"`
-
-### alb\_stickiness\_enabled
-
-Description: Enable ALB session stickiness (default false)
-
-Type: `string`
-
-Default: `"false"`
-
-### alb\_subnet\_ids
-
-Description: VPC subnet IDs in which to create the ALB (unnecessary if neither alb_enable_https or alb_enable_http are true)
-
-Type: `list`
-
-Default: `<list>`
-
-### app\_port
-
-Description: Numeric port on which application listens (unnecessary if neither alb_enable_https or alb_enable_http are true)
-
-Type: `string`
-
-Default: `""`
-
-### docker\_command
-
-Description: String to override CMD in Docker container (default "")
-
-Type: `string`
-
-Default: `""`
-
-### docker\_environment
-
-Description: List of environment maps of format { "name" = "var_name", "value" = "var_value" }
-
-Type: `list`
-
-Default: `<list>`
-
-### docker\_memory
-
-Description: Hard limit on memory use for task container (default 256)
-
-Type: `string`
-
-Default: `"256"`
-
-### docker\_memory\_reservation
-
-Description: Soft limit on memory use for task container (default 128)
-
-Type: `string`
-
-Default: `"128"`
-
-### docker\_mount\_points
-
-Description: List of mount point maps of format { "sourceVolume" = "vol_name", "containerPath" = "path", ["readOnly" = "true or false" ] }
-
-Type: `list`
-
-Default: `<list>`
-
-### docker\_port\_mappings
-
-Description: List of port mapping maps of format { "containerPort" = integer, [ "hostPort" = integer, "protocol" = "tcp or udp" ] }
-
-Type: `list`
-
-Default: `<list>`
-
-### ecs\_data\_volume\_path
-
-Description: Path to volume on ECS node to be defined as a "data" volume (default "/opt/data")
-
-Type: `string`
-
-Default: `"/opt/data"`
-
-### ecs\_deployment\_maximum\_percent
-
-Description: Upper limit in percentage of tasks that can be running during a deployment (default 200)
-
-Type: `string`
-
-Default: `"200"`
-
-### ecs\_deployment\_minimum\_healthy\_percent
-
-Description: Lower limit in percentage of tasks that must remain healthy during a deployment (default 100)
-
-Type: `string`
-
-Default: `"100"`
-
-### ecs\_desired\_count
-
-Description: Desired number of containers in the task (default 1)
-
-Type: `string`
-
-Default: `"1"`
-
-### ecs\_health\_check\_grace\_period
-
-Description: Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 1800. (default 0)
-
-Type: `string`
-
-Default: `"0"`
-
-### ecs\_log\_retention
-
-Description: Number of days of ECS task logs to retain (default 3)
-
-Type: `string`
-
-Default: `"3"`
-
-### ecs\_placement\_strategy\_field
-
-Description: Container metadata field to use when distributing tasks (default memory)
-
-Type: `string`
-
-Default: `"memory"`
-
-### ecs\_placement\_strategy\_type
-
-Description: Placement strategy to use when distributing tasks (default binpack)
-
-Type: `string`
-
-Default: `"binpack"`
-
-### extra\_task\_policy\_arns
-
-Description: List of ARNs of IAM policies to be attached to the ECS task role (in addition to the default policy, so cannot be more than 9 ARNs)
-
-Type: `list`
-
-Default: `<list>`
-
-### lb\_log\_enabled
-
-Description: Enables/Disables logging to designated S3 bucket.  S3 bucket name (lb_bucket_name) is still required.  (default is true)
-
-Type: `string`
-
-Default: `"true"`
-
-### lb\_log\_prefix
-
-Description: Prefix for S3 bucket. (default is log/elb).
-
-Type: `string`
-
-Default: `"logs/elb"`
-
-### log\_group\_name
-
-Description: Name for CloudWatch Log Group that will receive collector logs (must be unique, default is created from service_identifier and task_identifier)
-
-Type: `string`
-
-Default: `""`
-
-### network\_mode
-
-Description: Docker network mode for task (default "bridge")
-
-Type: `string`
-
-Default: `"bridge"`
-
-### region
-
-Description: AWS region in which ECS cluster is located (default is 'us-east-1')
-
-Type: `string`
-
-Default: `"us-east-1"`
-
-### service\_identifier
-
-Description: Unique identifier for this pganalyze service (used in log prefix, service name etc.)
-
-Type: `string`
-
-Default: `"service"`
-
-### task\_identifier
-
-Description: Unique identifier for this pganalyze task (used in log prefix, service name etc.)
-
-Type: `string`
-
-Default: `"task"`
+  
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| acm\_cert\_domain | Domain name of ACM-managed certificate | string | `""` | no |
+| alb\_cookie\_duration | Duration of ALB session stickiness cookie in seconds (default 86400) | string | `"86400"` | no |
+| alb\_enable\_http | Enable HTTP listener in ALB (default false) | string | `"false"` | no |
+| alb\_enable\_https | Enable HTTPS listener in ALB (default true) | string | `"true"` | no |
+| alb\_healthcheck\_healthy\_threshold | Number of consecutive successful health checks before marking service as healthy (default 5) | string | `"5"` | no |
+| alb\_healthcheck\_interval | Time in seconds between ALB health checks (default 30) | string | `"30"` | no |
+| alb\_healthcheck\_matcher | HTTP response codes to accept as healthy (default 200) | string | `"200"` | no |
+| alb\_healthcheck\_path | URI path for ALB health checks (default /) | string | `"/"` | no |
+| alb\_healthcheck\_port | Port for ALB to use when connecting health checks (default same as application traffic) | string | `"traffic-port"` | no |
+| alb\_healthcheck\_protocol | Protocol for ALB to use when connecting health checks (default HTTP) | string | `"HTTP"` | no |
+| alb\_healthcheck\_timeout | Timeout in seconds for ALB to use when connecting health checks (default 5) | string | `"5"` | no |
+| alb\_healthcheck\_unhealthy\_threshold | Number of consecutive failed health checks before marking service as unhealthy (default 2) | string | `"5"` | no |
+| alb\_internal | Configure ALB as internal-only (default false) | string | `"false"` | no |
+| alb\_stickiness\_enabled | Enable ALB session stickiness (default false) | string | `"false"` | no |
+| alb\_subnet\_ids | VPC subnet IDs in which to create the ALB (unnecessary if neither alb_enable_https or alb_enable_http are true) | list | `<list>` | no |
+| app\_port | Numeric port on which application listens (unnecessary if neither alb_enable_https or alb_enable_http are true) | string | `""` | no |
+| docker\_command | String to override CMD in Docker container (default "") | string | `""` | no |
+| docker\_environment | List of environment maps of format { "name" = "var_name", "value" = "var_value" } | list | `<list>` | no |
+| docker\_image | Docker image to use for task | string | n/a | yes |
+| docker\_memory | Hard limit on memory use for task container (default 256) | string | `"256"` | no |
+| docker\_memory\_reservation | Soft limit on memory use for task container (default 128) | string | `"128"` | no |
+| docker\_mount\_points | List of mount point maps of format { "sourceVolume" = "vol_name", "containerPath" = "path", ["readOnly" = "true or false" ] } | list | `<list>` | no |
+| docker\_port\_mappings | List of port mapping maps of format { "containerPort" = integer, [ "hostPort" = integer, "protocol" = "tcp or udp" ] } | list | `<list>` | no |
+| ecs\_cluster\_arn | ARN of ECS cluster in which the service will be deployed | string | n/a | yes |
+| ecs\_data\_volume\_path | Path to volume on ECS node to be defined as a "data" volume (default "/opt/data") | string | `"/opt/data"` | no |
+| ecs\_deployment\_maximum\_percent | Upper limit in percentage of tasks that can be running during a deployment (default 200) | string | `"200"` | no |
+| ecs\_deployment\_minimum\_healthy\_percent | Lower limit in percentage of tasks that must remain healthy during a deployment (default 100) | string | `"100"` | no |
+| ecs\_desired\_count | Desired number of containers in the task (default 1) | string | `"1"` | no |
+| ecs\_health\_check\_grace\_period | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 1800. (default 0) | string | `"0"` | no |
+| ecs\_log\_retention | Number of days of ECS task logs to retain (default 3) | string | `"3"` | no |
+| ecs\_placement\_strategy\_field | Container metadata field to use when distributing tasks (default memory) | string | `"memory"` | no |
+| ecs\_placement\_strategy\_type | Placement strategy to use when distributing tasks (default binpack) | string | `"binpack"` | no |
+| ecs\_security\_group\_id | Security group ID of ECS cluster in which the service will be deployed | string | n/a | yes |
+| extra\_task\_policy\_arns | List of ARNs of IAM policies to be attached to the ECS task role (in addition to the default policy, so cannot be more than 9 ARNs) | list | `<list>` | no |
+| lb\_bucket\_name | Full name for S3 bucket. | string | n/a | yes |
+| lb\_log\_enabled | Enables/Disables logging to designated S3 bucket.  S3 bucket name (lb_bucket_name) is still required.  (default is true) | string | `"true"` | no |
+| lb\_log\_prefix | Prefix for S3 bucket. (default is log/elb). | string | `"logs/elb"` | no |
+| log\_group\_name | Name for CloudWatch Log Group that will receive collector logs (must be unique, default is created from service_identifier and task_identifier) | string | `""` | no |
+| network\_mode | Docker network mode for task (default "bridge") | string | `"bridge"` | no |
+| region | AWS region in which ECS cluster is located (default is 'us-east-1') | string | `"us-east-1"` | no |
+| service\_identifier | Unique identifier for this pganalyze service (used in log prefix, service name etc.) | string | `"service"` | no |
+| task\_identifier | Unique identifier for this pganalyze task (used in log prefix, service name etc.) | string | `"task"` | no |
+| vpc\_id | ID of VPC in which ECS cluster is located | string | n/a | yes |
 
 ## Outputs
 
-The following outputs are exported:
+| Name | Description |
+|------|-------------|
+| alb\_arn | ARN of ALB provisioned for service (if present) |
+| alb\_dns\_name | FQDN of ALB provisioned for service (if present) |
+| alb\_zone\_id | Route 53 zone ID of ALB provisioned for service (if present) |
+| log\_group\_arn | ARN of the CloudWatch Log Group |
+| log\_group\_name | Name of the CloudWatch Log Group |
+| service\_iam\_role\_arn | ARN of the IAM Role for the ECS Service |
+| service\_iam\_role\_name | Name of the IAM Role for the ECS Task |
+| task\_iam\_role\_arn | ARN of the IAM Role for the ECS Task |
+| task\_iam\_role\_name | Name of the IAM Role for the ECS Task |
 
-### alb\_arn
-
-Description: ARN of ALB provisioned for service (if present)
-
-### alb\_dns\_name
-
-Description: FQDN of ALB provisioned for service (if present)
-
-### alb\_zone\_id
-
-Description: Route 53 zone ID of ALB provisioned for service (if present)
-
-### log\_group\_arn
-
-Description: ARN of the CloudWatch Log Group
-
-### log\_group\_name
-
-Description: Name of the CloudWatch Log Group
-
-### service\_iam\_role\_arn
-
-Description: ARN of the IAM Role for the ECS Service
-
-### service\_iam\_role\_name
-
-Description: Name of the IAM Role for the ECS Task
-
-### task\_iam\_role\_arn
-
-Description: ARN of the IAM Role for the ECS Task
-
-### task\_iam\_role\_name
-
-Description: Name of the IAM Role for the ECS Task

--- a/alb.tf
+++ b/alb.tf
@@ -1,5 +1,3 @@
-# ALB
-
 data "aws_acm_certificate" "alb" {
   count       = "${var.alb_enable_https ? 1 : 0}"
   domain      = "${var.acm_cert_domain}"

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,5 +1,3 @@
-# ECS SERVICE
-
 locals {
   docker_command_override = "${length(var.docker_command) > 0 ? "\"command\": [\"${var.docker_command}\"]," : ""}"
 }

--- a/iam.tf
+++ b/iam.tf
@@ -48,19 +48,18 @@ data "aws_iam_policy_document" "assume_role_service" {
 }
 
 resource "aws_iam_role" "task" {
-  name_prefix        = "${var.service_identifier}-${var.task_identifier}-ecsTaskRole"
+  description        = "${var.service_identifier}-${var.task_identifier}-ecsTaskRole"
   path               = "/${var.service_identifier}/"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role_task.json}"
 }
 
 resource "aws_iam_role_policy" "task" {
-  name_prefix = "${var.service_identifier}-${var.task_identifier}-ecsTaskPolicy"
-  role        = "${aws_iam_role.task.id}"
-  policy      = "${data.aws_iam_policy_document.task_policy.json}"
+  role   = "${aws_iam_role.task.id}"
+  policy = "${data.aws_iam_policy_document.task_policy.json}"
 }
 
 resource "aws_iam_role" "service" {
-  name_prefix        = "${var.service_identifier}-${var.task_identifier}-ecsSvcRole"
+  description        = "${var.service_identifier}-${var.task_identifier}-ecsServiceRole"
   path               = "/${var.service_identifier}/"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role_service.json}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-# MAIN
-
 data "aws_region" "region" {
   name = "${var.region}"
 }


### PR DESCRIPTION
removed the name_prefix parameter from aws_iam_role and
aws_iam_role_policy. They have caused nothing but trouble since you
can't pass long string in as names, we keep running into AWS errors
trying to deploy aws_iam_role and aws_iam_role_policy resources with
names that are human readable, and frankly never use the human readable
names.

Also, updated the README format to be more readable, as well as other tf
file formating for readability, no other changes.