### PR TITLE
Add alb_deregistration_delay as module parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This software is released under the MIT License (see `LICENSE`).
 |------|-------------|:----:|:-----:|:-----:|
 | acm\_cert\_domain | Domain name of ACM-managed certificate | string | `""` | no |
 | alb\_cookie\_duration | Duration of ALB session stickiness cookie in seconds (default 86400) | string | `"86400"` | no |
+| alb\_deregistration\_delay | The amount of time in seconds to wait before deregistering a target from a target group (default) | string | `"300"` | no |
 | alb\_enable\_http | Enable HTTP listener in ALB (default false) | string | `"false"` | no |
 | alb\_enable\_https | Enable HTTPS listener in ALB (default true) | string | `"true"` | no |
 | alb\_healthcheck\_healthy\_threshold | Number of consecutive successful health checks before marking service as healthy (default 5) | string | `"5"` | no |
@@ -107,4 +108,3 @@ This software is released under the MIT License (see `LICENSE`).
 | service\_iam\_role\_name | Name of the IAM Role for the ECS Task |
 | task\_iam\_role\_arn | ARN of the IAM Role for the ECS Task |
 | task\_iam\_role\_name | Name of the IAM Role for the ECS Task |
-

--- a/alb.tf
+++ b/alb.tf
@@ -60,6 +60,7 @@ resource "aws_alb_target_group" "service" {
   port     = "${var.app_port}"
   protocol = "HTTP"
   vpc_id   = "${data.aws_vpc.vpc.id}"
+  deregistration_delay = "${var.alb_deregistration_delay}"
 
   health_check {
     interval            = "${var.alb_healthcheck_interval}"

--- a/variables.tf
+++ b/variables.tf
@@ -221,3 +221,8 @@ variable "alb_cookie_duration" {
   description = "Duration of ALB session stickiness cookie in seconds (default 86400)"
   default     = "86400"
 }
+
+variable "alb_deregistration_delay" {
+    description = "The amount of time in seconds to wait before deregistering a target from a target group."
+    default     = "300"
+}


### PR DESCRIPTION
This PR exposes a parameter to define the underlying ALB's deregistration delay. 