### PR TITLE
Update to be FARGATE compatible

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -53,11 +53,11 @@ resource "aws_alb_listener" "service_http" {
 }
 
 resource "aws_alb_target_group" "service" {
-  name     = "${var.service_identifier}-${var.task_identifier}"
-  port     = var.app_port
-  protocol = "HTTP"
+  name                 = "${var.service_identifier}-${var.task_identifier}"
+  port                 = var.app_port
+  protocol             = "HTTP"
   deregistration_delay = var.alb_deregistration_delay
-  vpc_id   = data.aws_vpc.vpc.id
+  vpc_id               = data.aws_vpc.vpc.id
 
   health_check {
     interval            = var.alb_healthcheck_interval
@@ -109,11 +109,11 @@ resource "aws_security_group_rule" "alb_ingress_http" {
 }
 
 resource "aws_security_group_rule" "alb_egress" {
-  count                    = var.alb_enable_https || var.alb_enable_http ? 1 : 0
-  type                     = "egress"
-  from_port                = 0
-  to_port                  = 65535
-  protocol                 = "-1"
-  cidr_blocks              = var.alb_sg_cidr_egress
-  security_group_id        = aws_security_group.alb[0].id
+  count             = var.alb_enable_https || var.alb_enable_http ? 1 : 0
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "-1"
+  cidr_blocks       = var.alb_sg_cidr_egress
+  security_group_id = aws_security_group.alb[0].id
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -22,10 +22,14 @@ data "template_file" "container_definition" {
 }
 
 resource "aws_ecs_task_definition" "task" {
-  family                = "${var.service_identifier}-${var.task_identifier}"
-  container_definitions = data.template_file.container_definition.rendered
-  network_mode          = var.network_mode
-  task_role_arn         = aws_iam_role.task.arn
+  family                   = "${var.service_identifier}-${var.task_identifier}"
+  container_definitions    = data.template_file.container_definition.rendered
+  network_mode             = var.network_mode
+  requires_compatibilities = var.req_compatibilities
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.task_execution_role.arn
+  task_role_arn            = aws_iam_role.task.arn
 
   volume {
     name      = "data"
@@ -46,7 +50,7 @@ resource "aws_ecs_service" "service" {
   health_check_grace_period_seconds  = var.ecs_health_check_grace_period
 
   deployment_controller {
-    type   = var.deployment_controller_type
+    type = var.deployment_controller_type
   }
 
   ordered_placement_strategy {

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -9,7 +9,7 @@
         "portMappings": [
           {
             "containerPort": ${app_port},
-            "hostPort": 0,
+            "hostPort": ${host_port},
             "protocol": "tcp"
           }
         ],

--- a/iam.tf
+++ b/iam.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "assume_role_service" {
 }
 
 resource "aws_iam_role" "task" {
-  name_prefix               = "${var.service_identifier}-${var.task_identifier}-ecsTaskRole"
+  name_prefix        = "${var.service_identifier}-${var.task_identifier}-ecsTaskRole"
   path               = "/${var.service_identifier}/"
   assume_role_policy = data.aws_iam_policy_document.assume_role_task.json
 
@@ -56,13 +56,13 @@ resource "aws_iam_role" "task" {
 }
 
 resource "aws_iam_role_policy" "task" {
-  name_prefix   = "${var.service_identifier}-${var.task_identifier}-ecsTaskPolicy"
-  role   = aws_iam_role.task.name
-  policy = data.aws_iam_policy_document.task_policy.json
+  name_prefix = "${var.service_identifier}-${var.task_identifier}-ecsTaskPolicy"
+  role        = aws_iam_role.task.name
+  policy      = data.aws_iam_policy_document.task_policy.json
 }
 
 resource "aws_iam_role" "service" {
-  name_prefix               = "${var.service_identifier}-${var.task_identifier}-ecsServiceRole"
+  name_prefix        = "${var.service_identifier}-${var.task_identifier}-ecsServiceRole"
   path               = "/${var.service_identifier}/"
   assume_role_policy = data.aws_iam_policy_document.assume_role_service.json
 
@@ -78,4 +78,15 @@ resource "aws_iam_role_policy_attachment" "task_extra" {
   count      = length(var.extra_task_policy_arns)
   role       = aws_iam_role.task.name
   policy_arn = var.extra_task_policy_arns[count.index]
+}
+
+resource "aws_iam_role" "task_execution_role" {
+  name               = "${var.service_identifier}-${var.task_identifier}-ecsTaskExecutionRole"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_task.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "task-execution-role-policy-attachment" {
+  role       = aws_iam_role.task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,7 @@ variable "ecs_deployment_minimum_healthy_percent" {
 
 variable "deployment_controller_type" {
   description = "Type of deployment controller. Valid values: CODE_DEPLOY, ECS. Default: ECS."
-  default = "ECS"
+  default     = "ECS"
 }
 
 variable "ecs_health_check_grace_period" {
@@ -90,6 +90,21 @@ variable "network_mode" {
   default     = "bridge"
 }
 
+variable "req_compatibilities" {
+  description = "Launch type required by the task. Either EC2 or FARGATE"
+  default     = "[EC2]"
+}
+
+variable "cpu" {
+  description = "Number of cpu units used by the task. Required for FARGATE type"
+  default     = null
+}
+
+variable "memory" {
+  description = "Amount (in MiB) of memory used by the task. Required for FARGATE type"
+  default     = null
+}
+
 variable "service_identifier" {
   description = "Unique identifier for this pganalyze service (used in log prefix, service name etc.)"
   default     = "service"
@@ -103,7 +118,7 @@ variable "task_identifier" {
 variable "log_group_name" {
   type        = string
   description = "Name for CloudWatch Log Group that will receive collector logs (must be unique, default is created from service_identifier and task_identifier)"
-  default     = ""
+  default     = null
 }
 
 variable "extra_task_policy_arns" {
@@ -115,7 +130,7 @@ variable "extra_task_policy_arns" {
 variable "acm_cert_domain" {
   type        = string
   description = "Domain name of ACM-managed certificate"
-  default     = ""
+  default     = null
 }
 
 variable "alb_enable_https" {
@@ -153,6 +168,11 @@ variable "app_port" {
   description = "Numeric port on which application listens (unnecessary if neither alb_enable_https or alb_enable_http are true)"
 }
 
+variable "host_port" {
+  description = "Numeric port on which you want to map it to on the host"
+  default = 0
+}
+
 variable "ecs_placement_strategy_type" {
   description = "Placement strategy to use when distributing tasks (default spread)"
   default     = "spread"
@@ -178,7 +198,7 @@ variable "lb_bucket_name" {
 }
 
 variable "lb_prefix_override" {
-  default = ""
+  default = null
 }
 
 variable "lb_log_prefix" {
@@ -237,11 +257,11 @@ variable "alb_cookie_duration" {
 }
 
 variable "alb_deregistration_delay" {
-    description = "The amount of time in seconds to wait before deregistering a target from a target group."
-    default     = "300"
+  description = "The amount of time in seconds to wait before deregistering a target from a target group."
+  default     = "300"
 }
 
 variable "tags" {
   description = "Map of tags for everything but an ALB."
-  default = {}
+  default     = {}
 }


### PR DESCRIPTION
# Issue
- Throws error when changing the task launch type from EC2 to FARGATE 

# Changes
- Update to make this module compatible to create FARGATE launch type tasks when required
- Add requires_compatibilities, cpu, memory, execution_role_arn attributes to task_definition block which are required for fargate 
- Terraform fmt