### PR TITLE
Feature/update module to be fargate compatible

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -1,32 +1,29 @@
 locals {
   docker_command_override = length(var.docker_command) > 0 ? "\"command\": [\"${var.docker_command}\"]," : ""
-}
-
-data "template_file" "container_definition" {
-  template = file("${path.module}/files/container_definition.json")
-
-  vars = {
-    service_identifier    = var.service_identifier
-    task_identifier       = var.task_identifier
-    image                 = var.docker_image
-    memory                = var.docker_memory
-    memory_reservation    = var.docker_memory_reservation
-    app_port              = var.app_port
-    host_port             = var.host_port
-    command_override      = local.docker_command_override
-    environment           = jsonencode(var.docker_environment)
-    mount_points          = jsonencode(var.docker_mount_points)
-    awslogs_region        = data.aws_region.region.name
-    awslogs_group         = "${var.service_identifier}-${var.task_identifier}"
-    awslogs_stream_prefix = var.service_identifier
-    volume_name           = var.volume_name
-    ecs_data_volume_path  = var.ecs_data_volume_path
-  }
+  container_def = templatefile("${path.module}/files/container_definition.json",
+    {
+      service_identifier    = var.service_identifier
+      task_identifier       = var.task_identifier
+      image                 = var.docker_image
+      memory                = var.docker_memory
+      memory_reservation    = var.docker_memory_reservation
+      app_port              = var.app_port
+      host_port             = var.host_port
+      command_override      = local.docker_command_override
+      environment           = jsonencode(var.docker_environment)
+      mount_points          = jsonencode(var.docker_mount_points)
+      awslogs_region        = data.aws_region.region.name
+      awslogs_group         = "${var.service_identifier}-${var.task_identifier}"
+      awslogs_stream_prefix = var.service_identifier
+      volume_name           = var.volume_name
+      ecs_data_volume_path  = var.ecs_data_volume_path
+    }
+  )
 }
 
 resource "aws_ecs_task_definition" "task" {
   family                   = "${var.service_identifier}-${var.task_identifier}"
-  container_definitions    = data.template_file.container_definition.rendered
+  container_definitions    = local.container_def
   network_mode             = var.network_mode
   requires_compatibilities = var.req_compatibilities
   cpu                      = var.cpu

--- a/ecs.tf
+++ b/ecs.tf
@@ -19,6 +19,8 @@ data "template_file" "container_definition" {
     awslogs_region        = data.aws_region.region.name
     awslogs_group         = "${var.service_identifier}-${var.task_identifier}"
     awslogs_stream_prefix = var.service_identifier
+    volume_name           = var.volume_name
+    ecs_data_volume_path  = var.ecs_data_volume_path
   }
 }
 
@@ -33,8 +35,7 @@ resource "aws_ecs_task_definition" "task" {
   task_role_arn            = aws_iam_role.task.arn
 
   volume {
-    name      = "data"
-    host_path = var.ecs_data_volume_path
+    name      = var.volume_name
   }
 
   tags = var.tags

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -26,6 +26,11 @@
                "awslogs-region": "${awslogs_region}",
                "awslogs-stream-prefix": "${awslogs_stream_prefix}"
             }
+        },
+        "mountPoints": {
+          "readOnly": null,
+          "sourceVolume": "${volume_name}",
+          "containerPath": "${ecs_data_volume_path}"
         }
     }
 ]

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -13,6 +13,13 @@
             "protocol": "tcp"
           }
         ],
+        "mountPoints": [
+          {
+            "readOnly": null,
+            "sourceVolume": "${volume_name}",
+            "containerPath": "${ecs_data_volume_path}"
+          }
+        ],
         ${command_override}
         "environment": ${environment},
         "mountPoints": ${mount_points},
@@ -26,11 +33,6 @@
                "awslogs-region": "${awslogs_region}",
                "awslogs-stream-prefix": "${awslogs_stream_prefix}"
             }
-        },
-        "mountPoints": {
-          "readOnly": null,
-          "sourceVolume": "${volume_name}",
-          "containerPath": "${ecs_data_volume_path}"
         }
     }
 ]

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,11 @@ variable "docker_mount_points" {
   default     = []
 }
 
+variable "volume_name" {
+  description = "Name of the volume to be mounted"
+  default = "data"
+}
+
 variable "ecs_data_volume_path" {
   description = "Path to volume on ECS node to be defined as a \"data\" volume (default \"/opt/data\")"
   default     = "/opt/data"


### PR DESCRIPTION
# Issue
- Error while deploying in `terraform-payments` 
```
ClientException: Fargate compatible task definitions do not support sourcePath
```

# Changes
- Remove the `host_path` attribute from volume block. FARGATE launch type does not accept this attribute
- Create a mountpoint block in container definition to pass the volume path
- Removed the data template_file to make the module plan on mac os

# Note
- Tested by planning locally