### PR TITLE
Feature/update module to be fargate compatible

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 #*       @global-owner1 @global-owner2
-*       @FitnessKeeper/devops
+*       @FitnessKeeper/infrastructure
 
 # Order is important; the last matching pattern takes the most
 # precedence. When someone opens a pull request that only

--- a/alb.tf
+++ b/alb.tf
@@ -56,6 +56,7 @@ resource "aws_alb_target_group" "service" {
   name                 = "${var.service_identifier}-${var.task_identifier}"
   port                 = var.app_port
   protocol             = "HTTP"
+  target_type          = var.target_type
   deregistration_delay = var.alb_deregistration_delay
   vpc_id               = data.aws_vpc.vpc.id
 

--- a/ecs.tf
+++ b/ecs.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "task" {
   task_role_arn            = aws_iam_role.task.arn
 
   volume {
-    name      = var.volume_name
+    name = var.volume_name
   }
 
   tags = var.tags
@@ -43,7 +43,7 @@ resource "aws_ecs_service" "service" {
   cluster                            = var.ecs_cluster_arn
   task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = var.ecs_desired_count
-  iam_role                           = aws_iam_role.service.arn
+  iam_role                           = var.network_mode != "awsvpc" ? aws_iam_role.service.arn : null
   deployment_maximum_percent         = var.ecs_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_deployment_minimum_healthy_percent
   health_check_grace_period_seconds  = var.ecs_health_check_grace_period

--- a/ecs.tf
+++ b/ecs.tf
@@ -57,6 +57,15 @@ resource "aws_ecs_service" "service" {
     field = var.ecs_placement_strategy_field
   }
 
+  dynamic "network_configuration" {
+    for_each = var.network_config
+    content {
+      security_groups  = var.nc_security_groups == "" ? null : var.nc_security_groups
+      subnets          = var.nc_subnets == "" ? null : var.nc_subnets
+      assign_public_ip = var.nc_assign_public_ip == "" ? null : var.nc_assign_public_ip
+    }
+  }
+
   load_balancer {
     target_group_arn = aws_alb_target_group.service.arn
     container_name   = "${var.service_identifier}-${var.task_identifier}"

--- a/variables.tf
+++ b/variables.tf
@@ -169,6 +169,11 @@ variable "alb_subnet_ids" {
   default     = []
 }
 
+variable "target_type" {
+  description = "Type of target that you must specify when registering targets with this target group"
+  default = "instance"
+}
+
 variable "app_port" {
   description = "Numeric port on which application listens (unnecessary if neither alb_enable_https or alb_enable_http are true)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -275,3 +275,28 @@ variable "tags" {
   description = "Map of tags for everything but an ALB."
   default     = {}
 }
+
+variable "network_config" {
+  description = "Applicable when networkmode is fargate"
+  type = list(object({
+    security_groups  = optional(list(string))
+    subnets          = optional(list(string))
+    assign_public_ip = optional(bool)
+  }))
+  default = []
+}
+
+variable "nc_security_groups" {
+  description = "Security groups associated with the task or service"
+  default     = null
+}
+
+variable "nc_subnets" {
+  description = "Subnets associated with the task or service"
+  default     = null
+}
+
+variable "nc_assign_public_ip" {
+  description = "Assign a public IP address to the ENI"
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -77,7 +77,7 @@ variable "docker_mount_points" {
 
 variable "volume_name" {
   description = "Name of the volume to be mounted"
-  default = "data"
+  default     = "data"
 }
 
 variable "ecs_data_volume_path" {
@@ -171,7 +171,7 @@ variable "alb_subnet_ids" {
 
 variable "target_type" {
   description = "Type of target that you must specify when registering targets with this target group"
-  default = "instance"
+  default     = "instance"
 }
 
 variable "app_port" {
@@ -180,7 +180,7 @@ variable "app_port" {
 
 variable "host_port" {
   description = "Numeric port on which you want to map it to on the host"
-  default = 0
+  default     = 0
 }
 
 variable "ecs_placement_strategy_type" {


### PR DESCRIPTION
# Issue
- Fargate launch type doesn't support `instance` target type 
- Ecs service requires the network configuration to be setup when using `awsvpc` mode
- InvalidParameterException: You cannot specify an IAM role for services that require a service linked role

# Changes
- Create a variable to accept target type. Defaults to `instance`.  
- Fargate launch type requires the target type to be `ip`
- Create an optional dynamic block for `network_configuration` in ecs_service which is required for `awsvpc` network mode or `FARGATE` launch type
- Make `iam_role` as null, when using fargate launch type
- Update `CODEOWNERS` to `fitnesskeeper/infrastructure`

# circleCI build
https://app.circleci.com/pipelines/github/FitnessKeeper/terraform-payments/98/workflows/10c03928-1073-4b76-870b-f3d8d17ee500/jobs/457