### PR TITLE
Fix deploy errors for fargate compatibility changes

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -23,7 +23,7 @@ resource "aws_alb" "service" {
     prefix  = coalesce(var.lb_prefix_override, "${var.lb_log_prefix}/${var.service_identifier}/${var.task_identifier}")
   }
 
-  tags = var.tags
+  tags = local.default_tags
 }
 
 resource "aws_alb_listener" "service_https" {
@@ -77,7 +77,7 @@ resource "aws_alb_target_group" "service" {
     cookie_duration = var.alb_cookie_duration
   }
 
-  tags = var.tags
+  tags = local.default_tags
 }
 
 resource "aws_security_group" "alb" {
@@ -86,7 +86,7 @@ resource "aws_security_group" "alb" {
   description = "Security group for ${var.service_identifier}-${var.task_identifier} ALB"
   vpc_id      = data.aws_vpc.vpc.id
 
-  tags = var.tags
+  tags = local.default_tags
 }
 
 resource "aws_security_group_rule" "alb_ingress_https" {

--- a/ecs.tf
+++ b/ecs.tf
@@ -5,6 +5,7 @@ locals {
       service_identifier    = var.service_identifier
       task_identifier       = var.task_identifier
       image                 = var.docker_image
+      docker_secret         = var.docker_secret
       memory                = var.docker_memory
       cpu                   = var.cpu
       memory_reservation    = var.docker_memory_reservation

--- a/ecs.tf
+++ b/ecs.tf
@@ -58,9 +58,12 @@ resource "aws_ecs_service" "service" {
     type = var.deployment_controller_type
   }
 
-  ordered_placement_strategy {
-    type  = var.ecs_placement_strategy_type
-    field = var.ecs_placement_strategy_field
+  dynamic "ordered_placement_strategy" {
+    for_each = var.placement_strategy
+    content {
+      type  = var.ecs_placement_strategy_type
+      field = var.ecs_placement_strategy_field
+    }
   }
 
   dynamic "network_configuration" {

--- a/ecs.tf
+++ b/ecs.tf
@@ -41,7 +41,7 @@ resource "aws_ecs_task_definition" "task" {
     }
   }
 
-  tags = var.tags
+  tags = local.default_tags
 }
 
 resource "aws_ecs_service" "service" {
@@ -49,7 +49,7 @@ resource "aws_ecs_service" "service" {
   cluster                            = var.ecs_cluster_arn
   task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = var.ecs_desired_count
-  launch_type                        = var.launch_type 
+  launch_type                        = var.launch_type
   iam_role                           = var.network_mode != "awsvpc" ? aws_iam_role.service.arn : null
   deployment_maximum_percent         = var.ecs_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_deployment_minimum_healthy_percent
@@ -89,7 +89,7 @@ resource "aws_ecs_service" "service" {
     aws_iam_role.service,
   ]
 
-  tags = var.tags
+  tags = local.default_tags
 }
 
 resource "aws_cloudwatch_log_group" "task" {

--- a/ecs.tf
+++ b/ecs.tf
@@ -48,6 +48,7 @@ resource "aws_ecs_service" "service" {
   cluster                            = var.ecs_cluster_arn
   task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = var.ecs_desired_count
+  launch_type                        = var.launch_type 
   iam_role                           = var.network_mode != "awsvpc" ? aws_iam_role.service.arn : null
   deployment_maximum_percent         = var.ecs_deployment_maximum_percent
   deployment_minimum_healthy_percent = var.ecs_deployment_minimum_healthy_percent

--- a/ecs.tf
+++ b/ecs.tf
@@ -6,6 +6,7 @@ locals {
       task_identifier       = var.task_identifier
       image                 = var.docker_image
       memory                = var.docker_memory
+      cpu                   = var.cpu
       memory_reservation    = var.docker_memory_reservation
       app_port              = var.app_port
       host_port             = var.host_port

--- a/ecs.tf
+++ b/ecs.tf
@@ -31,8 +31,12 @@ resource "aws_ecs_task_definition" "task" {
   execution_role_arn       = aws_iam_role.task_execution_role.arn
   task_role_arn            = aws_iam_role.task.arn
 
-  volume {
-    name = var.volume_name
+  dynamic "volume" {
+    for_each = var.task_volume
+    content {
+      name      = var.task_volume == "" ? null : var.volume_name
+      host_path = var.task_volume == "" ? null : var.ecs_data_volume_path
+    }
   }
 
   tags = var.tags

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -3,7 +3,7 @@
         "name": "${service_identifier}-${task_identifier}",
         "image": "${image}",
         "memory": ${memory},
-        "cpu": 0,
+        "cpu": ${cpu},
         "essential": true,
         "memoryReservation": ${memory_reservation},
         "portMappings": [

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -13,7 +13,6 @@
             "protocol": "tcp"
           }
         ],
-        "mountPoints": [],
         ${command_override}
         "environment": ${environment},
         "mountPoints": ${mount_points},

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -1,31 +1,32 @@
 [
-    {
-        "name": "${service_identifier}-${task_identifier}",
-        "image": "${image}",
-        "memory": ${memory},
-        "cpu": ${cpu},
-        "essential": true,
-        "memoryReservation": ${memory_reservation},
-        "portMappings": [
-          {
-            "containerPort": ${app_port},
-            "hostPort": ${host_port},
-            "protocol": "tcp"
-          }
-        ],
-        ${command_override}
-        "environment": ${environment},
-        "mountPoints": ${mount_points},
-        "volumesFrom": [
-          
-        ],
-        "logConfiguration": {
-            "logDriver": "awslogs",
-            "options": {
-               "awslogs-group": "${awslogs_group}",
-               "awslogs-region": "${awslogs_region}",
-               "awslogs-stream-prefix": "${awslogs_stream_prefix}"
-            }
+  {
+    "name": "${service_identifier}-${task_identifier}",
+    "image": "${image}",
+    "repositoryCredentials": {
+      "credentialsParameter": "${docker_secret}"
+    },
+    "memory": ${memory},
+    "cpu": ${cpu},
+    "essential": true,
+    "memoryReservation": ${memory_reservation},
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${host_port},
+        "protocol": "tcp"
+      }
+    ],
+    ${command_override}
+    "environment": ${environment},
+    "mountPoints": ${mount_points},
+    "volumesFrom": [],
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+           "awslogs-group": "${awslogs_group}",
+           "awslogs-region": "${awslogs_region}",
+           "awslogs-stream-prefix": "${awslogs_stream_prefix}"
         }
     }
+  }
 ]

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -13,13 +13,7 @@
             "protocol": "tcp"
           }
         ],
-        "mountPoints": [
-          {
-            "readOnly": null,
-            "sourceVolume": "${volume_name}",
-            "containerPath": "${ecs_data_volume_path}"
-          }
-        ],
+        "mountPoints": [],
         ${command_override}
         "environment": ${environment},
         "mountPoints": ${mount_points},

--- a/iam.tf
+++ b/iam.tf
@@ -15,6 +15,8 @@ data "aws_iam_policy_document" "task_policy" {
     actions = [
       "cloudwatch:GetMetricStatistics",
       "logs:DescribeLogStreams",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
       "logs:GetLogEvents",
       "logs:PutLogEvents",
     ]
@@ -60,7 +62,7 @@ resource "aws_iam_role" "task" {
   path               = "/${var.service_identifier}/"
   assume_role_policy = data.aws_iam_policy_document.assume_role_task.json
 
-  tags = var.tags
+  tags = local.default_tags
 }
 
 resource "aws_iam_role_policy" "task" {
@@ -74,7 +76,7 @@ resource "aws_iam_role" "service" {
   path               = "/${var.service_identifier}/"
   assume_role_policy = data.aws_iam_policy_document.assume_role_service.json
 
-  tags = var.tags
+  tags = local.default_tags
 }
 
 resource "aws_iam_role_policy_attachment" "service" {
@@ -91,7 +93,7 @@ resource "aws_iam_role_policy_attachment" "task_extra" {
 resource "aws_iam_role" "task_execution_role" {
   name               = "${var.service_identifier}-${var.task_identifier}-ecsTaskExecutionRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role_task.json
-  tags               = var.tags
+  tags               = local.default_tags
 }
 
 resource "aws_iam_role_policy_attachment" "task-execution-role-policy-attachment" {

--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,6 @@ data "aws_iam_policy_document" "task_policy" {
     actions = [
       "cloudwatch:GetMetricStatistics",
       "logs:DescribeLogStreams",
-      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:GetLogEvents",
       "logs:PutLogEvents",

--- a/iam.tf
+++ b/iam.tf
@@ -47,6 +47,14 @@ data "aws_iam_policy_document" "assume_role_service" {
   }
 }
 
+data "aws_iam_policy_document" "task_execution_role_policy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = ["${var.docker_secret}"]
+  }
+}
+
 resource "aws_iam_role" "task" {
   name_prefix        = "${var.service_identifier}-${var.task_identifier}-ecsTaskRole"
   path               = "/${var.service_identifier}/"
@@ -89,4 +97,10 @@ resource "aws_iam_role" "task_execution_role" {
 resource "aws_iam_role_policy_attachment" "task-execution-role-policy-attachment" {
   role       = aws_iam_role.task_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "task_execution_role_policy" {
+  name   = "${var.service_identifier}-${var.task_identifier}-ecs-task-execution-role-policy"
+  role   = aws_iam_role.task_execution_role.id
+  policy = data.aws_iam_policy_document.task_execution_role_policy.json
 }

--- a/main.tf
+++ b/main.tf
@@ -6,3 +6,10 @@ data "aws_vpc" "vpc" {
   id = var.vpc_id
 }
 
+locals {
+  default_tags = {
+    TerraformManaged = "true"
+    Env              = var.env
+    Application      = var.service_identifier
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@ variable "region" {
   default     = "us-east-1"
 }
 
+variable "env" {
+  type        = string
+  description = "Environment of an application"
+}
+
 variable "vpc_id" {
   type        = string
   description = "ID of VPC in which ECS cluster is located"
@@ -112,7 +117,6 @@ variable "memory" {
 
 variable "service_identifier" {
   description = "Unique identifier for this pganalyze service (used in log prefix, service name etc.)"
-  default     = "service"
 }
 
 variable "task_identifier" {
@@ -269,11 +273,6 @@ variable "alb_cookie_duration" {
 variable "alb_deregistration_delay" {
   description = "The amount of time in seconds to wait before deregistering a target from a target group."
   default     = "300"
-}
-
-variable "tags" {
-  description = "Map of tags for everything but an ALB."
-  default     = {}
 }
 
 variable "network_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -314,3 +314,10 @@ variable "launch_type" {
   description = "Launch type on which to run the service. Default is EC2"
   default     = "EC2"
 }
+
+variable "placement_strategy" {
+  type = list(object({
+    type  = string
+    field = optional(string)
+  }))
+}

--- a/variables.tf
+++ b/variables.tf
@@ -304,7 +304,7 @@ variable "nc_assign_public_ip" {
 variable "task_volume" {
   description = "optional volume block in task definition. Do not pass any value for EC2 launch type"
   type = list(object({
-    name      = optional(string)
+    name      = string
     host_path = optional(string)
   }))
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -300,3 +300,12 @@ variable "nc_assign_public_ip" {
   description = "Assign a public IP address to the ENI"
   default     = null
 }
+
+variable "task_volume" {
+  description = "optional volume block in task definition. Do not pass any value for EC2 launch type"
+  type = list(object({
+    name      = optional(string)
+    host_path = optional(string)
+  }))
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -321,3 +321,8 @@ variable "placement_strategy" {
     field = optional(string)
   }))
 }
+
+variable "docker_secret" {
+  description = "arn of the secret to be used for dockerhub authentication"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -309,3 +309,8 @@ variable "task_volume" {
   }))
   default = []
 }
+
+variable "launch_type" {
+  description = "Launch type on which to run the service. Default is EC2"
+  default     = "EC2"
+}


### PR DESCRIPTION
# Changes
- Create a dynamic block to make the volume configuration optional in task definition
- Defaults to an empty list
- Need to pass value to task_volume when volume block is required
- assign a cpu variable in container definition
- Make the ordered_placement_strategy optional
- Add docker secret to access private registry
- Remove tags module and update with default_tags