### PR TITLE
Sre 1854 refactor payments api task def to load secrets directly from ssm or secrets manager

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -74,7 +74,13 @@ data "aws_iam_policy_document" "task_execution_role_policy" {
   statement {
     effect    = "Allow"
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = ["${var.docker_secret}"]
+    resources = concat([var.docker_secret], var.secret_arns)
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = [var.encryption_key]
   }
 
   statement {
@@ -83,6 +89,6 @@ data "aws_iam_policy_document" "task_execution_role_policy" {
       "ecs:ExecuteCommand",
       "ecs:DescribeTasks"
     ]
-    resources = [aws_ecs_task_definition.task.arn]
+    resources = ["${aws_ecs_task_definition.task.arn}:*"]
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_task_definition" "task" {
 resource "aws_ecs_service" "service" {
   name                               = "${var.service_identifier}-${var.task_identifier}-service"
   cluster                            = var.ecs_cluster_arn
-  task_definition                    = aws_ecs_task_definition.task.arn
+  task_definition                    = "${aws_ecs_task_definition.task.id}:${aws_ecs_task_definition.task.revision}"
   desired_count                      = var.ecs_desired_count
   launch_type                        = var.launch_type
   iam_role                           = var.network_mode != "awsvpc" ? aws_iam_role.service.arn : null

--- a/ecs.tf
+++ b/ecs.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_task_definition" "task" {
 resource "aws_ecs_service" "service" {
   name                               = "${var.service_identifier}-${var.task_identifier}-service"
   cluster                            = var.ecs_cluster_arn
-  task_definition                    = "${aws_ecs_task_definition.task.id}:${aws_ecs_task_definition.task.revision}"
+  task_definition                    = aws_ecs_task_definition.task.arn
   desired_count                      = var.ecs_desired_count
   launch_type                        = var.launch_type
   iam_role                           = var.network_mode != "awsvpc" ? aws_iam_role.service.arn : null

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -31,7 +31,8 @@
            "awslogs-group": "${awslogs_group}",
            "awslogs-region": "${awslogs_region}",
            "awslogs-stream-prefix": "${awslogs_stream_prefix}"
-        }
+        },
+        "secretOptions": "${secrets}"
     }
   }
 ]

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -27,12 +27,12 @@
     "volumesFrom": [],
     "logConfiguration": {
         "logDriver": "awslogs",
+        ${secrets}
         "options": {
            "awslogs-group": "${awslogs_group}",
            "awslogs-region": "${awslogs_region}",
            "awslogs-stream-prefix": "${awslogs_stream_prefix}"
-        },
-        "secretOptions": "${secrets}"
+        }
     }
   }
 ]

--- a/locals.tf
+++ b/locals.tf
@@ -38,6 +38,7 @@ locals {
       awslogs_region        = data.aws_region.region.name
       awslogs_group         = aws_cloudwatch_log_group.task.name
       awslogs_stream_prefix = var.service_identifier
+      secrets               = jsonencode(var.secrets)
     }
   )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -18,6 +18,8 @@ locals {
     }
   }
 
+  secrets = length(var.secrets) > 0 ? "\"secretOptions\": ${jsonencode(var.secrets)}," : ""
+
   container_def = templatefile("${path.module}/files/container_definition.json",
     {
       service_identifier    = var.service_identifier
@@ -38,7 +40,7 @@ locals {
       awslogs_region        = data.aws_region.region.name
       awslogs_group         = aws_cloudwatch_log_group.task.name
       awslogs_stream_prefix = var.service_identifier
-      secrets               = jsonencode(var.secrets)
+      secrets               = local.secrets
     }
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -317,12 +317,15 @@ variable "entrypoint" {
 
 variable "secrets" {
   description = "Secrets to be passed to the container environment"
+  default     = ""
 }
 
 variable "secret_arns" {
   description = "Arn of the secrets that are passed to the container environment"
+  default     = null
 }
 
 variable "encryption_key" {
-  
+  description = "Kms key to decrypt secrets"
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -314,3 +314,15 @@ variable "entrypoint" {
   description = "The entry point that's passed to the container. Use [ \"sleep\", \"60\" ], when enabling exec command"
   default     = ""
 }
+
+variable "secrets" {
+  description = "Secrets to be passed to the container environment"
+}
+
+variable "secret_arns" {
+  description = "Arn of the secrets that are passed to the container environment"
+}
+
+variable "encryption_key" {
+  
+}


### PR DESCRIPTION
# Changes
- Add an optional secretOptions attribute to the container definition to pass sensitive values to the container environment
- Allow task_execution_role to retrieve secrets and decrypt them with a kms key