### PR TITLE
Replace secretoptions with scerets

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -89,6 +89,6 @@ data "aws_iam_policy_document" "task_execution_role_policy" {
       "ecs:ExecuteCommand",
       "ecs:DescribeTasks"
     ]
-    resources = ["${aws_ecs_task_definition.task.arn}:*"]
+    resources = [aws_ecs_task_definition.task.arn]
   }
 }

--- a/files/container_definition.json
+++ b/files/container_definition.json
@@ -5,6 +5,7 @@
     "repositoryCredentials": {
       "credentialsParameter": "${docker_secret}"
     },
+    ${secrets}
     "memory": ${memory},
     "cpu": ${cpu},
     "essential": true,
@@ -27,7 +28,6 @@
     "volumesFrom": [],
     "logConfiguration": {
         "logDriver": "awslogs",
-        ${secretsoptions}
         "options": {
            "awslogs-group": "${awslogs_group}",
            "awslogs-region": "${awslogs_region}",

--- a/locals.tf
+++ b/locals.tf
@@ -18,7 +18,7 @@ locals {
     }
   }
 
-  secrets = length(var.secrets) > 0 ? "\"secretOptions\": ${jsonencode(var.secrets)}," : ""
+  secrets = length(var.secrets) > 0 ? "\"secrets\": ${jsonencode(var.secrets)}," : ""
 
   container_def = templatefile("${path.module}/files/container_definition.json",
     {
@@ -40,7 +40,7 @@ locals {
       awslogs_region        = data.aws_region.region.name
       awslogs_group         = aws_cloudwatch_log_group.task.name
       awslogs_stream_prefix = var.service_identifier
-      secretsoptions        = local.secrets
+      secrets               = local.secrets
     }
   )
 }


### PR DESCRIPTION
# Changes
- Use `secrets` attribute to pass secrets to container environment
- Fix the resource value in `task_execution_role_policy`. Tried to set a wild cart for task definition revision but got an error saying the task definition has to be `fully qualified and cannot contain regexes`

# Testing in dev 
Was able to retrieve secrets inside container using secrets attribute
https://us-east-1.console.aws.amazon.com/ecs/v2/task-definitions/payments-dev-api/77/json?region=us-east-1