### PR TITLE
SRE-2222-deploy-succesfully-on-dev-using-ghcr-image

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -2,7 +2,7 @@ resource "aws_ecs_task_definition" "task" {
   family = "${var.service_identifier}-${var.task_identifier}"
   container_definitions = jsonencode([{
     name  = "${var.service_identifier}-${var.task_identifier}"
-    image = nonsensitive(var.docker_image)
+    image = var.docker_image
     repositoryCredentials = {
       credentialsParameter = var.docker_secret
     }


### PR DESCRIPTION
# Changes
- Removing redundant nonsensitive() as docker_image will not be sensitive value anymore