### PR TITLE
SRE-2715-make-ssm-param-and-kms-key-arns-optional-for-terraform-aws-ecs-service

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -77,10 +77,29 @@ data "aws_iam_policy_document" "task_execution_role_policy" {
     resources = concat([var.docker_secret], var.secret_arns)
   }
 
-  statement {
-    effect    = "Allow"
-    actions   = ["kms:Decrypt"]
-    resources = var.encryption_keys
+  dynamic "statement" {
+    for_each = length(var.ssm_param_arns) > 0 ? [1] : []
+
+    content {
+      effect = "Allow"
+      actions = [
+        "ssm:GetParameter",
+        "ssm:GetParameters"
+      ]
+      resources = var.ssm_param_arns
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.encryption_keys) > 0 ? [1] : []
+
+    content {
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt"
+      ]
+      resources = var.encryption_keys
+    }
   }
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -330,3 +330,9 @@ variable "encryption_keys" {
   type        = list(string)
   default     = []
 }
+
+variable "ssm_param_arns" {
+  description = "Arn of the ssm parameters that are passed to the container environment"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
# Changes
- Add dynamic statement blocks for accessing ssm parameters and kms key, otherwise making it mandatory to pass these values