### PR TITLE
SRE-3022-make-alb-creation-optional-in-terraform-aws-ecs-service-module

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -23,7 +23,7 @@ resource "aws_alb_listener" "service_https" {
   certificate_arn   = data.aws_acm_certificate.alb[0].arn
 
   default_action {
-    target_group_arn = aws_alb_target_group.service[0].arn
+    target_group_arn = aws_alb_target_group.service.arn
     type             = "forward"
   }
 }
@@ -35,13 +35,12 @@ resource "aws_alb_listener" "service_http" {
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_alb_target_group.service[0].arn
+    target_group_arn = aws_alb_target_group.service.arn
     type             = "forward"
   }
 }
 
 resource "aws_alb_target_group" "service" {
-  count                = var.create_alb ? 1 : 0
   name                 = "${var.service_identifier}-${var.task_identifier}"
   port                 = var.app_port
   protocol             = "HTTP"

--- a/ecs.tf
+++ b/ecs.tf
@@ -86,13 +86,10 @@ resource "aws_ecs_service" "service" {
     }
   }
 
-  dynamic "load_balancer" {
-    for_each = var.create_alb ? [1] : []
-    content {
-      target_group_arn = var.create_alb ? aws_alb_target_group.service[0].arn : var.alb_target_group_arn
-      container_name   = "${var.service_identifier}-${var.task_identifier}"
-      container_port   = var.app_port
-    }
+  load_balancer {
+    target_group_arn = aws_alb_target_group.service.arn 
+    container_name   = "${var.service_identifier}-${var.task_identifier}"
+    container_port   = var.app_port
   }
 
   depends_on = [

--- a/ecs.tf
+++ b/ecs.tf
@@ -86,10 +86,13 @@ resource "aws_ecs_service" "service" {
     }
   }
 
-  load_balancer {
-    target_group_arn = aws_alb_target_group.service.arn
-    container_name   = "${var.service_identifier}-${var.task_identifier}"
-    container_port   = var.app_port
+  dynamic "load_balancer" {
+    for_each = var.create_alb ? [1] : []
+    content {
+      target_group_arn = var.create_alb ? aws_alb_target_group.service[0].arn : var.alb_target_group_arn
+      container_name   = "${var.service_identifier}-${var.task_identifier}"
+      container_port   = var.app_port
+    }
   }
 
   depends_on = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,12 +15,12 @@ output "alb_zone_id" {
 
 output "alb_https_listener_arn" {
   description = "ARN of the HTTPS Listener (if present)"
-  value       = var.alb_enable_https ? aws_alb_listener.service_https[0].arn : "not created"
+  value       = var.create_alb && var.alb_enable_https ? aws_alb_listener.service_https[0].arn : "not created"
 }
 
 output "target_group_arn" {
   description = "ARN of the target group provisioned for service"
-  value       = aws_alb_target_group.service.arn
+  value       = var.create_alb ? aws_alb_target_group.service[0].arn : "not created"
 }
 
 output "task_iam_role_arn" {
@@ -55,5 +55,5 @@ output "log_group_arn" {
 
 output "alb_sg_id" {
   description = "Load balancer security group id"
-  value       = aws_security_group.alb.0.id
+  value       = var.create_alb ? aws_security_group.alb.0.id : "not created"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "alb_https_listener_arn" {
 
 output "target_group_arn" {
   description = "ARN of the target group provisioned for service"
-  value       = var.create_alb ? aws_alb_target_group.service[0].arn : "not created"
+  value       = aws_alb_target_group.service.arn
 }
 
 output "task_iam_role_arn" {
@@ -55,5 +55,5 @@ output "log_group_arn" {
 
 output "alb_sg_id" {
   description = "Load balancer security group id"
-  value       = var.create_alb ? aws_security_group.alb.0.id : "not created"
+  value       = var.create_alb ? aws_security_group.alb.0.id : "not created by module"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -343,9 +343,3 @@ variable "create_alb" {
   type        = bool
   default     = true
 }
-
-variable "alb_target_group_arn" {
-  description = "The ARN of the ALB target group"
-  type        = string
-  default     = ""
-}

--- a/variables.tf
+++ b/variables.tf
@@ -337,3 +337,15 @@ variable "ssm_param_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "create_alb" {
+  description = "Whether to create ALB and related resources"
+  type        = bool
+  default     = true
+}
+
+variable "alb_target_group_arn" {
+  description = "The ARN of the ALB target group"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
# Changes
- Making the loadbalancer creation optional in this module is required for contentkeeper-cms
- Made sure these changes will not disrupt the already existing projects using this module