### PR TITLE
SRE-3068-restruct-dynamic-network-configuration-block-to-remove-redundancy-in-terraform-aws-ecs-module

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -78,16 +78,16 @@ resource "aws_ecs_service" "service" {
   }
 
   dynamic "network_configuration" {
-    for_each = var.network_config
+    for_each = var.network_config # 'var.environment' should be set to the desired stage like 'stg20' or 'stg25'
     content {
-      security_groups  = var.nc_security_groups == "" ? null : var.nc_security_groups
-      subnets          = var.nc_subnets == "" ? null : var.nc_subnets
-      assign_public_ip = var.nc_assign_public_ip == "" ? null : var.nc_assign_public_ip
+      security_groups  = network_configuration.value.security_groups
+      subnets          = network_configuration.value.subnets
+      assign_public_ip = network_configuration.value.assign_public_ip
     }
   }
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.service.arn 
+    target_group_arn = aws_alb_target_group.service.arn
     container_name   = "${var.service_identifier}-${var.task_identifier}"
     container_port   = var.app_port
   }

--- a/ecs.tf
+++ b/ecs.tf
@@ -78,7 +78,7 @@ resource "aws_ecs_service" "service" {
   }
 
   dynamic "network_configuration" {
-    for_each = var.network_config # 'var.environment' should be set to the desired stage like 'stg20' or 'stg25'
+    for_each = var.network_config
     content {
       security_groups  = network_configuration.value.security_groups
       subnets          = network_configuration.value.subnets

--- a/variables.tf
+++ b/variables.tf
@@ -264,21 +264,6 @@ variable "network_config" {
   default = []
 }
 
-variable "nc_security_groups" {
-  description = "Security groups associated with the task or service"
-  default     = null
-}
-
-variable "nc_subnets" {
-  description = "Subnets associated with the task or service"
-  default     = null
-}
-
-variable "nc_assign_public_ip" {
-  description = "Assign a public IP address to the ENI"
-  default     = null
-}
-
 variable "task_volume" {
   description = "optional volume block in task definition. Do not pass any value for FARGATE launch type"
   type = list(object({


### PR DESCRIPTION
# Changes
- Restructure dynamic network_congifuration block to remove redundant variables